### PR TITLE
Initial bindings for PersistentRooted

### DIFF
--- a/crates/spidermonkey-wasm-sys/src/api.cpp
+++ b/crates/spidermonkey-wasm-sys/src/api.cpp
@@ -48,3 +48,11 @@ bool Utf8SourceEvaluate(JSContext* context, const JS::OwningCompileOptions& opts
   return JS::Evaluate(context, opts, src, rval);
 }
 
+std::unique_ptr<JS::PersistentRootedObject> MakeUninitPersistentRootedObject() {
+  return std::make_unique<JS::PersistentRootedObject>();
+}
+
+void InitPersistentRootedObject(JS::PersistentRootedObject& obj, JSContext* context, JSObject* initial) {
+  obj.init(context, initial);
+}
+

--- a/crates/spidermonkey-wasm-sys/src/api.cpp
+++ b/crates/spidermonkey-wasm-sys/src/api.cpp
@@ -56,3 +56,6 @@ void InitPersistentRootedObject(JS::PersistentRootedObject& obj, JSContext* cont
   obj.init(context, initial);
 }
 
+uint32_t DefaultHeapMaxBytes() {
+  return JS::DefaultHeapMaxBytes;
+}

--- a/crates/spidermonkey-wasm-sys/src/api.h
+++ b/crates/spidermonkey-wasm-sys/src/api.h
@@ -52,3 +52,7 @@ std::unique_ptr<Utf8UnitSourceText> MakeUtf8UnitSourceText();
 bool InitDefaultSelfHostedCode(JSContext* context);
 bool InitUtf8UnitSourceText(JSContext* context, Utf8UnitSourceText& src, rust::Str units, size_t length, JS::SourceOwnership ownership);
 bool Utf8SourceEvaluate(JSContext* context, const JS::OwningCompileOptions& opts, Utf8UnitSourceText& src, JS::MutableHandle<JS::Value> rval);
+
+std::unique_ptr<JS::PersistentRootedObject> MakeUninitPersistentRootedObject();
+void InitPersistentRootedObject(JS::PersistentRootedObject& obj, JSContext* context, JSObject* initial);
+

--- a/crates/spidermonkey-wasm-sys/src/api.h
+++ b/crates/spidermonkey-wasm-sys/src/api.h
@@ -44,6 +44,8 @@ struct CompileOptionsParams;
 
 typedef JS::SourceText<mozilla::Utf8Unit> Utf8UnitSourceText;
 
+uint32_t DefaultHeapMaxBytes();
+
 std::unique_ptr<JSClass> MakeDefaultGlobalClass();
 std::unique_ptr<JS::RealmOptions> MakeDefaultRealmOptions();
 std::unique_ptr<JS::OwningCompileOptions> MakeOwningCompileOptions(JSContext* context, const CompileOptionsParams &opts);

--- a/crates/spidermonkey-wasm-sys/src/lib.rs
+++ b/crates/spidermonkey-wasm-sys/src/lib.rs
@@ -124,7 +124,6 @@ pub mod jsffi {
         fn JS_Init() -> bool;
         fn JS_ShutDown();
 
-
         fn MakeDefaultGlobalClass() -> UniquePtr<JSClass>;
         fn MakeDefaultRealmOptions() -> UniquePtr<RealmOptions>;
         unsafe fn MakeOwningCompileOptions(

--- a/crates/spidermonkey-wasm-sys/src/lib.rs
+++ b/crates/spidermonkey-wasm-sys/src/lib.rs
@@ -134,6 +134,7 @@ pub mod jsffi {
 
         unsafe fn InitDefaultSelfHostedCode(context: *mut JSContext) -> bool;
 
+        unsafe fn JS_NewPlainObject(context: *mut JSContext) -> *mut JSObject;
         unsafe fn JS_NewGlobalObject(
             context: *mut JSContext,
             klass: *const JSClass,
@@ -152,7 +153,6 @@ pub mod jsffi {
         fn toInt32(self: &Value) -> i32;
 
         unsafe fn MakeUtf8UnitSourceText() -> UniquePtr<Utf8UnitSourceText>;
-
         unsafe fn InitUtf8UnitSourceText(
             context: *mut JSContext,
             src: Pin<&mut Utf8UnitSourceText>,
@@ -160,7 +160,6 @@ pub mod jsffi {
             length: usize,
             ownership: SourceOwnership,
         ) -> bool;
-
         unsafe fn Utf8SourceEvaluate(
             context: *mut JSContext,
             compile_opts: &OwningCompileOptions,

--- a/crates/spidermonkey-wasm-sys/src/lib.rs
+++ b/crates/spidermonkey-wasm-sys/src/lib.rs
@@ -81,6 +81,8 @@ pub mod jsffi {
         #[namespace = "JS"]
         type Value = crate::jsval::Value;
         #[namespace = "JS"]
+        type PersistentRootedObject;
+        #[namespace = "JS"]
         type RootedObject = crate::jsgc::Rooted<*mut JSObject>;
         #[namespace = "JS"]
         type RootedValue = crate::jsgc::Rooted<Value>;
@@ -160,5 +162,13 @@ pub mod jsffi {
             source: Pin<&mut Utf8UnitSourceText>,
             rval: MutableHandleValue,
         ) -> bool;
+
+        fn MakeUninitPersistentRootedObject() -> UniquePtr<PersistentRootedObject>;
+        unsafe fn InitPersistentRootedObject(
+            root: Pin<&mut PersistentRootedObject>,
+            context: *mut JSContext,
+            initial: *mut JSObject,
+        );
+        fn initialized(self: &PersistentRootedObject) -> bool;
     }
 }

--- a/crates/spidermonkey-wasm-sys/src/lib.rs
+++ b/crates/spidermonkey-wasm-sys/src/lib.rs
@@ -118,6 +118,7 @@ pub mod jsffi {
         type ReadOnlyCompileOptions;
 
         unsafe fn JS_NewContext(max_bytes: u32, parent: *mut JSRuntime) -> *mut JSContext;
+        fn DefaultHeapMaxBytes() -> u32;
         fn JS_Init() -> bool;
 
         fn MakeDefaultGlobalClass() -> UniquePtr<JSClass>;

--- a/crates/spidermonkey-wasm-sys/src/lib.rs
+++ b/crates/spidermonkey-wasm-sys/src/lib.rs
@@ -118,8 +118,12 @@ pub mod jsffi {
         type ReadOnlyCompileOptions;
 
         unsafe fn JS_NewContext(max_bytes: u32, parent: *mut JSRuntime) -> *mut JSContext;
+        unsafe fn JS_DestroyContext(context: *mut JSContext);
         fn DefaultHeapMaxBytes() -> u32;
+
         fn JS_Init() -> bool;
+        fn JS_ShutDown();
+
 
         fn MakeDefaultGlobalClass() -> UniquePtr<JSClass>;
         fn MakeDefaultRealmOptions() -> UniquePtr<RealmOptions>;

--- a/crates/spidermonkey-wasm-sys/tests/integration.rs
+++ b/crates/spidermonkey-wasm-sys/tests/integration.rs
@@ -81,7 +81,11 @@ mod integration {
         let mut persistent = jsffi::MakeUninitPersistentRootedObject();
         assert!(!persistent.initialized());
         unsafe {
-            jsffi::InitPersistentRootedObject(persistent.pin_mut(), context, JS_NewPlainObject(context));
+            jsffi::InitPersistentRootedObject(
+                persistent.pin_mut(),
+                context,
+                JS_NewPlainObject(context),
+            );
         }
         assert!(persistent.initialized());
         shutdown_engine(context);

--- a/crates/spidermonkey-wasm-sys/tests/integration.rs
+++ b/crates/spidermonkey-wasm-sys/tests/integration.rs
@@ -1,16 +1,31 @@
 mod integration {
+    use spidermonkey_wasm_sys::jsffi::JS_NewPlainObject;
     use spidermonkey_wasm_sys::{jsffi, jsgc, jsrealm};
     use std::marker::PhantomData;
     use std::ptr;
 
+    fn init_engine() -> *mut jsffi::JSContext {
+        assert!(jsffi::JS_Init());
+        unsafe {
+            let context = jsffi::JS_NewContext(jsffi::DefaultHeapMaxBytes(), ptr::null_mut());
+            assert!(!context.is_null());
+            context
+        }
+    }
+
+    fn shutdown_engine(context: *mut jsffi::JSContext) {
+        unsafe {
+            jsffi::JS_DestroyContext(context);
+        }
+        jsffi::JS_ShutDown();
+    }
+
     #[test]
     fn eval() {
         let global_class = jsffi::MakeDefaultGlobalClass();
-        assert!(jsffi::JS_Init());
+        let context = init_engine();
 
         unsafe {
-            let context = jsffi::JS_NewContext(32 * 32 * 1024, ptr::null_mut());
-            assert!(!context.is_null());
             assert!(jsffi::InitDefaultSelfHostedCode(context));
 
             let realm_opts = jsffi::MakeDefaultRealmOptions();
@@ -56,5 +71,19 @@ mod integration {
             let result = undefined_value.toInt32();
             assert_eq!(result, 42);
         }
+
+        shutdown_engine(context);
+    }
+
+    #[test]
+    fn init_persistent_rooted() {
+        let context = init_engine();
+        let mut persistent = jsffi::MakeUninitPersistentRootedObject();
+        assert!(!persistent.initialized());
+        unsafe {
+            jsffi::InitPersistentRootedObject(persistent.pin_mut(), context, JS_NewPlainObject(context));
+        }
+        assert!(persistent.initialized());
+        shutdown_engine(context);
     }
 }


### PR DESCRIPTION
This PR adds the initial bindings to interact with `PersistentRooted` objects. It also introduces a small cleanup in the integration tests, ensuring that each test initializes and stops the engine. 