### PR TITLE
Initial high level Runtime implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,12 @@ jobs:
           cargo wasi test
           cd -
 
+      - name: Test spidermonkey-wasm
+        run: |
+          cd crates/spidermonkey-wasm
+          cargo wasi test
+          cd -
+
       - name: Lint
         run: cargo fmt -- --check
  

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
 members = [
   "crates/spidermonkey-wasm-sys",
+  "crates/spidermonkey-wasm",
 ]

--- a/crates/spidermonkey-wasm-sys/src/lib.rs
+++ b/crates/spidermonkey-wasm-sys/src/lib.rs
@@ -118,6 +118,7 @@ pub mod jsffi {
         #[namespace = "JS"]
         type ReadOnlyCompileOptions;
 
+        unsafe fn JS_GetRuntime(context: *mut JSContext) -> *mut JSRuntime;
         unsafe fn JS_NewContext(max_bytes: u32, parent: *mut JSRuntime) -> *mut JSContext;
         unsafe fn JS_DestroyContext(context: *mut JSContext);
         fn DefaultHeapMaxBytes() -> u32;

--- a/crates/spidermonkey-wasm/.cargo/config
+++ b/crates/spidermonkey-wasm/.cargo/config
@@ -1,0 +1,10 @@
+[build]
+target = "wasm32-wasi"
+
+[env]
+CXX = "/opt/wasi-sdk/wasi-sdk-12.0/bin/clang++ --sysroot=/opt/wasi-sdk/wasi-sdk-12.0/share/wasi-sysroot"
+CXXFLAGS = "-fno-exceptions -DRUST_CXX_NO_EXCEPTIONS"
+AR = "/opt/wasi-sdk/wasi-sdk-12.0/bin/ar"
+LIBCLANG_PATH = "/opt/wasi-sdk/wasi-sdk-12.0/share/wasi-sysroot/lib/wasm32-wasi"
+LIBCLANG_RT_PATH = "/opt/wasi-sdk/wasi-sdk-12.0/lib/clang/11.0.0/lib/wasi"
+

--- a/crates/spidermonkey-wasm/Cargo.toml
+++ b/crates/spidermonkey-wasm/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "spidermonkey-wasm"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+spidermonkey-wasm-sys = { path = "../spidermonkey-wasm-sys" }

--- a/crates/spidermonkey-wasm/src/lib.rs
+++ b/crates/spidermonkey-wasm/src/lib.rs
@@ -1,0 +1,1 @@
+mod runtime;

--- a/crates/spidermonkey-wasm/src/lib.rs
+++ b/crates/spidermonkey-wasm/src/lib.rs
@@ -1,1 +1,1 @@
-mod runtime;
+pub mod runtime;

--- a/crates/spidermonkey-wasm/src/runtime.rs
+++ b/crates/spidermonkey-wasm/src/runtime.rs
@@ -1,0 +1,59 @@
+use spidermonkey_wasm_sys::jsffi::{
+    DefaultHeapMaxBytes, JSContext, JSRuntime, JS_DestroyContext, JS_GetRuntime, JS_Init,
+    JS_NewContext, JS_ShutDown,
+};
+use std::ptr;
+
+pub struct Runtime {
+    context: *mut JSContext,
+}
+
+// This implementation doesn't reflect the entire parent-child
+// relationship between runtimes. It assumes a single, top level runtime
+// and a single context. This should be enough for the Wasm
+// use case. This implementation can be expanded if necessary.
+impl Default for Runtime {
+    fn default() -> Self {
+        assert!(JS_Init());
+
+        let context: *mut JSContext =
+            unsafe { JS_NewContext(DefaultHeapMaxBytes(), ptr::null_mut()) };
+
+        Self { context }
+    }
+}
+
+impl Runtime {
+    pub fn cx(&self) -> *mut JSContext {
+        self.context
+    }
+
+    pub fn rt(&self) -> *const JSRuntime {
+        unsafe { JS_GetRuntime(self.context) }
+    }
+}
+
+impl Drop for Runtime {
+    fn drop(&mut self) {
+        unsafe {
+            JS_DestroyContext(self.context);
+        }
+        JS_ShutDown();
+    }
+}
+
+mod test {
+    use super::Runtime;
+
+    #[test]
+    fn cx() {
+        let rt = Runtime::default();
+        assert!(!rt.cx().is_null());
+    }
+
+    #[test]
+    fn rt() {
+        let rt = Runtime::default();
+        assert!(!rt.rt().is_null());
+    }
+}


### PR DESCRIPTION
This PR introduces the initial implementation of a `Runtime` under
the high-level spidermonkey-wasm crate. This crate is the one that
should be consumed by anyone wanting to execute JS-on-Wasm