### PR TITLE
Hook InitSelfHostedCode and UseInternalJobQueues

### DIFF
--- a/crates/spidermonkey-wasm-sys/src/lib.rs
+++ b/crates/spidermonkey-wasm-sys/src/lib.rs
@@ -134,6 +134,8 @@ pub mod jsffi {
         ) -> UniquePtr<OwningCompileOptions>;
 
         unsafe fn InitDefaultSelfHostedCode(context: *mut JSContext) -> bool;
+        #[namespace = "js"]
+        unsafe fn UseInternalJobQueues(context: *mut JSContext) -> bool;
 
         unsafe fn JS_NewPlainObject(context: *mut JSContext) -> *mut JSObject;
         unsafe fn JS_NewGlobalObject(

--- a/crates/spidermonkey-wasm/src/runtime.rs
+++ b/crates/spidermonkey-wasm/src/runtime.rs
@@ -1,6 +1,6 @@
 use spidermonkey_wasm_sys::jsffi::{
-    DefaultHeapMaxBytes, JSContext, JSRuntime, JS_DestroyContext, JS_GetRuntime, JS_Init,
-    JS_NewContext, JS_ShutDown,
+    DefaultHeapMaxBytes, InitDefaultSelfHostedCode, JSContext, JSRuntime, JS_DestroyContext,
+    JS_GetRuntime, JS_Init, JS_NewContext, JS_ShutDown, UseInternalJobQueues,
 };
 use std::ptr;
 
@@ -18,6 +18,11 @@ impl Default for Runtime {
 
         let context: *mut JSContext =
             unsafe { JS_NewContext(DefaultHeapMaxBytes(), ptr::null_mut()) };
+
+        unsafe {
+            assert!(UseInternalJobQueues(context));
+            assert!(InitDefaultSelfHostedCode(context));
+        }
 
         Self { context }
     }
@@ -42,7 +47,9 @@ impl Drop for Runtime {
     }
 }
 
-mod test {
+#[cfg(test)]
+mod tests {
+
     use super::Runtime;
 
     #[test]


### PR DESCRIPTION
This PR hooks `UseInternalJobQueues` and `InitDefaultSelfHostedCode`
when constructing the Runtime; if more flexibility is needed,
a potential avenue is to change the implementation to allow specifying
if these initialization calls should be made.