### PR TITLE
High level rooting API

### DIFF
--- a/crates/spidermonkey-wasm-sys/src/jsgc.rs
+++ b/crates/spidermonkey-wasm-sys/src/jsgc.rs
@@ -38,43 +38,23 @@ impl<T> Default for Rooted<T> {
 }
 
 impl<T> Rooted<T> {
-    pub fn new(context: *mut JSContext, ptr: T) -> Self
+    pub unsafe fn init(&mut self, context: *mut JSContext, initial: T)
     where
         T: JSRootKind,
     {
-        let mut rooted = Self::default();
-        rooted.root(context, ptr);
-        rooted
-    }
-
-    fn root(&mut self, context: *mut JSContext, ptr: T)
-    where
-        T: JSRootKind,
-    {
+        self.ptr = initial;
         let kind = T::root_kind() as usize;
         let rooting_context = context as *mut RootingContext;
-        let root_stack: *mut *mut Rooted<*mut c_void> =
-            unsafe { &mut (*rooting_context).stackRoots_[kind] as *mut _ as *mut _ };
+        let stack: *mut *mut Rooted<*mut c_void> = &mut (*rooting_context).stackRoots_[kind] as *mut _ as *mut _;
 
-        self.stack = root_stack;
-        unsafe {
-            self.ptr = ptr;
-            self.prev = *root_stack;
-            *root_stack = self as *mut _ as usize as _;
-        }
+        self.stack = stack;
+        self.prev = *stack;
+        *stack = self as *mut _ as usize as _;
     }
 
-    fn remove_from_root_stack(&mut self) {
-        unsafe {
-            assert!(*self.stack == self as *mut _ as usize as _);
-            *self.stack = self.prev;
-        }
-    }
-}
-
-impl<T> Drop for Rooted<T> {
-    fn drop(&mut self) {
-        self.remove_from_root_stack();
+    pub unsafe fn remove_from_root_stack(&mut self) {
+        assert!(*self.stack == self as *mut _ as usize as _);
+        *self.stack = self.prev;
     }
 }
 

--- a/crates/spidermonkey-wasm-sys/src/jsgc.rs
+++ b/crates/spidermonkey-wasm-sys/src/jsgc.rs
@@ -45,7 +45,8 @@ impl<T> Rooted<T> {
         self.ptr = initial;
         let kind = T::root_kind() as usize;
         let rooting_context = context as *mut RootingContext;
-        let stack: *mut *mut Rooted<*mut c_void> = &mut (*rooting_context).stackRoots_[kind] as *mut _ as *mut _;
+        let stack: *mut *mut Rooted<*mut c_void> =
+            &mut (*rooting_context).stackRoots_[kind] as *mut _ as *mut _;
 
         self.stack = stack;
         self.prev = *stack;

--- a/crates/spidermonkey-wasm-sys/src/jsval.rs
+++ b/crates/spidermonkey-wasm-sys/src/jsval.rs
@@ -1,5 +1,6 @@
 #[repr(C)]
 #[allow(non_snake_case)]
+#[derive(Copy, Clone)]
 pub struct Value {
     pub asBits_: u64,
 }

--- a/crates/spidermonkey-wasm-sys/tests/integration.rs
+++ b/crates/spidermonkey-wasm-sys/tests/integration.rs
@@ -29,7 +29,8 @@ mod integration {
             assert!(jsffi::InitDefaultSelfHostedCode(context));
 
             let realm_opts = jsffi::MakeDefaultRealmOptions();
-            let global_object = jsgc::Rooted::new(
+            let mut global_object = jsgc::Rooted::default();
+            global_object.init(
                 context,
                 jsffi::JS_NewGlobalObject(
                     context,

--- a/crates/spidermonkey-wasm/src/handle.rs
+++ b/crates/spidermonkey-wasm/src/handle.rs
@@ -18,7 +18,7 @@ impl<'a, T: 'a> Handle<'a, T> {
         *self.ptr
     }
 
-    pub fn into_raw(&self) -> RawHandle<T> {
+    pub fn into_raw(self) -> RawHandle<T> {
         RawHandle {
             ptr: self.ptr as *const T,
             _marker: PhantomData,
@@ -35,7 +35,7 @@ impl<'a, T: 'a> MutableHandle<'a, T> {
         MutableHandle { ptr }
     }
 
-    pub fn into_raw(&mut self) -> RawMutableHandle<T> {
+    pub fn into_raw(self) -> RawMutableHandle<T> {
         RawMutableHandle {
             ptr: self.ptr as *mut T,
             _marker: PhantomData,

--- a/crates/spidermonkey-wasm/src/handle.rs
+++ b/crates/spidermonkey-wasm/src/handle.rs
@@ -12,12 +12,17 @@ impl<'a, T: 'a> Handle<'a, T> {
     }
 
     pub fn get(&self) -> T
-        where T: Copy {
+    where
+        T: Copy,
+    {
         *self.ptr
     }
 
     pub fn into_raw(&self) -> RawHandle<T> {
-        RawHandle { ptr: self.ptr as *const T, _marker: PhantomData }
+        RawHandle {
+            ptr: self.ptr as *const T,
+            _marker: PhantomData,
+        }
     }
 }
 
@@ -31,7 +36,9 @@ impl<'a, T: 'a> MutableHandle<'a, T> {
     }
 
     pub fn into_raw(&mut self) -> RawMutableHandle<T> {
-        RawMutableHandle { ptr: self.ptr as *mut T, _marker: PhantomData }
+        RawMutableHandle {
+            ptr: self.ptr as *mut T,
+            _marker: PhantomData,
+        }
     }
 }
-

--- a/crates/spidermonkey-wasm/src/handle.rs
+++ b/crates/spidermonkey-wasm/src/handle.rs
@@ -1,0 +1,37 @@
+use std::marker::PhantomData;
+
+use spidermonkey_wasm_sys::jsgc::{Handle as RawHandle, MutableHandle as RawMutableHandle};
+
+pub struct Handle<'a, T: 'a> {
+    ptr: &'a T,
+}
+
+impl<'a, T: 'a> Handle<'a, T> {
+    pub fn new(ptr: &T) -> Handle<T> {
+        Handle { ptr }
+    }
+
+    pub fn get(&self) -> T
+        where T: Copy {
+        *self.ptr
+    }
+
+    pub fn into_raw(&self) -> RawHandle<T> {
+        RawHandle { ptr: self.ptr as *const T, _marker: PhantomData }
+    }
+}
+
+pub struct MutableHandle<'a, T: 'a> {
+    ptr: &'a mut T,
+}
+
+impl<'a, T: 'a> MutableHandle<'a, T> {
+    pub fn new(ptr: &'a mut T) -> Self {
+        MutableHandle { ptr }
+    }
+
+    pub fn into_raw(&mut self) -> RawMutableHandle<T> {
+        RawMutableHandle { ptr: self.ptr as *mut T, _marker: PhantomData }
+    }
+}
+

--- a/crates/spidermonkey-wasm/src/lib.rs
+++ b/crates/spidermonkey-wasm/src/lib.rs
@@ -1,1 +1,3 @@
 pub mod runtime;
+pub mod rooted;
+pub mod handle;

--- a/crates/spidermonkey-wasm/src/lib.rs
+++ b/crates/spidermonkey-wasm/src/lib.rs
@@ -1,3 +1,9 @@
 pub mod runtime;
 pub mod rooted;
 pub mod handle;
+
+pub mod jsapi {
+    pub use spidermonkey_wasm_sys::jsffi::*;
+    pub use spidermonkey_wasm_sys::jsrealm; 
+    pub use spidermonkey_wasm_sys::jsgc; 
+}

--- a/crates/spidermonkey-wasm/src/lib.rs
+++ b/crates/spidermonkey-wasm/src/lib.rs
@@ -1,9 +1,9 @@
-pub mod runtime;
-pub mod rooted;
 pub mod handle;
+pub mod rooted;
+pub mod runtime;
 
 pub mod jsapi {
     pub use spidermonkey_wasm_sys::jsffi::*;
-    pub use spidermonkey_wasm_sys::jsrealm; 
-    pub use spidermonkey_wasm_sys::jsgc; 
+    pub use spidermonkey_wasm_sys::jsgc;
+    pub use spidermonkey_wasm_sys::jsrealm;
 }

--- a/crates/spidermonkey-wasm/src/rooted.rs
+++ b/crates/spidermonkey-wasm/src/rooted.rs
@@ -1,11 +1,12 @@
-use spidermonkey_wasm_sys::{jsgc::{Rooted as RawRooted, JSRootKind}, jsffi::JSContext};
 use crate::handle::{Handle, MutableHandle};
+use spidermonkey_wasm_sys::{
+    jsffi::JSContext,
+    jsgc::{JSRootKind, Rooted as RawRooted},
+};
 use std::pin::Pin;
 
 macro_rules! root {
-    () => {
-        
-    };
+    () => {};
 }
 
 // root!(
@@ -15,12 +16,13 @@ pub struct Rooted<'a, T: 'a + JSRootKind> {
 }
 
 impl<'a, T: 'a + JSRootKind> Rooted<'a, T> {
-     pub fn new(context: *mut JSContext, root: &'a mut RawRooted<T>, initial: T) -> Self {
-         unsafe { root.init(context, initial) };
+    pub fn new(context: *mut JSContext, root: &'a mut RawRooted<T>, initial: T) -> Self {
+        unsafe { root.init(context, initial) };
 
-         Self { root: unsafe { Pin::new_unchecked(root) } }
-     }
-    
+        Self {
+            root: unsafe { Pin::new_unchecked(root) },
+        }
+    }
 
     pub fn handle(&self) -> Handle<T> {
         Handle::new(&self.root.ptr)
@@ -34,9 +36,11 @@ impl<'a, T: 'a + JSRootKind> Rooted<'a, T> {
     }
 
     pub fn get(&self) -> T
-        where T: Copy{
-            self.root.ptr
-        }
+    where
+        T: Copy,
+    {
+        self.root.ptr
+    }
 }
 
 impl<'a, T: 'a + JSRootKind> Drop for Rooted<'a, T> {

--- a/crates/spidermonkey-wasm/src/rooted.rs
+++ b/crates/spidermonkey-wasm/src/rooted.rs
@@ -1,0 +1,51 @@
+use spidermonkey_wasm_sys::{jsgc::{Rooted as RawRooted, JSRootKind}, jsffi::JSContext};
+use crate::handle::{Handle, MutableHandle};
+use std::pin::Pin;
+
+macro_rules! root {
+    () => {
+        
+    };
+}
+
+// root!(
+
+pub struct Rooted<'a, T: 'a + JSRootKind> {
+    root: Pin<&'a mut RawRooted<T>>,
+}
+
+impl<'a, T: 'a + JSRootKind> Rooted<'a, T> {
+     pub fn new(context: *mut JSContext, root: &'a mut RawRooted<T>, initial: T) -> Self {
+         unsafe { root.init(context, initial) };
+
+         Self { root: unsafe { Pin::new_unchecked(root) } }
+     }
+    
+
+    pub fn handle(&self) -> Handle<T> {
+        Handle::new(&self.root.ptr)
+    }
+
+    pub fn mut_handle(&mut self) -> MutableHandle<T> {
+        let mut_pin = self.root.as_mut();
+        let raw_rooted = unsafe { mut_pin.get_unchecked_mut() };
+
+        MutableHandle::new(&mut raw_rooted.ptr)
+    }
+
+    pub fn get(&self) -> T
+        where T: Copy{
+            self.root.ptr
+        }
+}
+
+impl<'a, T: 'a + JSRootKind> Drop for Rooted<'a, T> {
+    fn drop(&mut self) {
+        inner_drop(self.root.as_mut());
+
+        fn inner_drop<'a, T: 'a + JSRootKind>(this: Pin<&'a mut RawRooted<T>>) {
+            let raw_root = unsafe { this.get_unchecked_mut() };
+            unsafe { raw_root.remove_from_root_stack() };
+        }
+    }
+}

--- a/crates/spidermonkey-wasm/tests/eval.rs
+++ b/crates/spidermonkey-wasm/tests/eval.rs
@@ -1,5 +1,5 @@
 mod eval {
-    use spidermonkey_wasm::{jsapi, rooted::Rooted, runtime::Runtime};
+    use spidermonkey_wasm::{jsapi, root, runtime::Runtime};
     use std::ptr;
 
     #[test]
@@ -10,17 +10,8 @@ mod eval {
 
         unsafe {
             let realm_opts = jsapi::MakeDefaultRealmOptions();
-            let mut default_global_root = jsapi::jsgc::Rooted::default();
-            let global_object = Rooted::new(
-                context,
-                &mut default_global_root,
-                jsapi::JS_NewGlobalObject(
-                    runtime.cx(),
-                    &*global_class,
-                    ptr::null_mut(),
-                    jsapi::OnNewGlobalHookOption::FireOnNewGlobalHook,
-                    &realm_opts,
-                ),
+            root!(with(context);
+                let global_object = jsapi::JS_NewGlobalObject(runtime.cx(), &*global_class, ptr::null_mut(), jsapi::OnNewGlobalHookOption::FireOnNewGlobalHook, &realm_opts);
             );
 
             let global_object_handle = global_object.handle();
@@ -34,9 +25,10 @@ mod eval {
                 },
             );
 
-            let mut unrooted_return_value = jsapi::jsgc::Rooted::default();
-            let mut return_value =
-                Rooted::new(context, &mut unrooted_return_value, jsapi::UndefinedValue());
+            root!(with(context);
+                let mut return_value = jsapi::UndefinedValue();
+            );
+
             let mut return_value_handle = return_value.mut_handle();
 
             let script = "41 + 1";

--- a/crates/spidermonkey-wasm/tests/eval.rs
+++ b/crates/spidermonkey-wasm/tests/eval.rs
@@ -1,5 +1,5 @@
 mod eval {
-    use spidermonkey_wasm::{runtime::Runtime, jsapi, rooted::Rooted};
+    use spidermonkey_wasm::{jsapi, rooted::Rooted, runtime::Runtime};
     use std::ptr;
 
     #[test]
@@ -11,13 +11,17 @@ mod eval {
         unsafe {
             let realm_opts = jsapi::MakeDefaultRealmOptions();
             let mut default_global_root = jsapi::jsgc::Rooted::default();
-            let global_object = Rooted::new(context, &mut default_global_root, jsapi::JS_NewGlobalObject(
-                runtime.cx(),
-                &*global_class,
-                ptr::null_mut(),
-                jsapi::OnNewGlobalHookOption::FireOnNewGlobalHook,
-                &realm_opts,
-            ));
+            let global_object = Rooted::new(
+                context,
+                &mut default_global_root,
+                jsapi::JS_NewGlobalObject(
+                    runtime.cx(),
+                    &*global_class,
+                    ptr::null_mut(),
+                    jsapi::OnNewGlobalHookOption::FireOnNewGlobalHook,
+                    &realm_opts,
+                ),
+            );
 
             let global_object_handle = global_object.handle();
             let _ar = jsapi::jsrealm::JSAutoRealm::new(context, global_object_handle.get());
@@ -31,7 +35,8 @@ mod eval {
             );
 
             let mut unrooted_return_value = jsapi::jsgc::Rooted::default();
-            let mut return_value = Rooted::new(context, &mut unrooted_return_value, jsapi::UndefinedValue());
+            let mut return_value =
+                Rooted::new(context, &mut unrooted_return_value, jsapi::UndefinedValue());
             let mut return_value_handle = return_value.mut_handle();
 
             let script = "41 + 1";
@@ -44,7 +49,12 @@ mod eval {
                 jsapi::SourceOwnership::Borrowed
             ));
 
-            jsapi::Utf8SourceEvaluate(context, &owning_compile_options, source.pin_mut(), return_value_handle.into_raw());
+            jsapi::Utf8SourceEvaluate(
+                context,
+                &owning_compile_options,
+                source.pin_mut(),
+                return_value_handle.into_raw(),
+            );
 
             let result = return_value.get().toInt32();
             assert_eq!(result, 42);

--- a/crates/spidermonkey-wasm/tests/eval.rs
+++ b/crates/spidermonkey-wasm/tests/eval.rs
@@ -1,0 +1,53 @@
+mod eval {
+    use spidermonkey_wasm::{runtime::Runtime, jsapi, rooted::Rooted};
+    use std::ptr;
+
+    #[test]
+    fn eval() {
+        let runtime = Runtime::default();
+        let global_class = jsapi::MakeDefaultGlobalClass();
+        let context = runtime.cx();
+
+        unsafe {
+            let realm_opts = jsapi::MakeDefaultRealmOptions();
+            let mut default_global_root = jsapi::jsgc::Rooted::default();
+            let global_object = Rooted::new(context, &mut default_global_root, jsapi::JS_NewGlobalObject(
+                runtime.cx(),
+                &*global_class,
+                ptr::null_mut(),
+                jsapi::OnNewGlobalHookOption::FireOnNewGlobalHook,
+                &realm_opts,
+            ));
+
+            let global_object_handle = global_object.handle();
+            let _ar = jsapi::jsrealm::JSAutoRealm::new(context, global_object_handle.get());
+            let owning_compile_options = jsapi::MakeOwningCompileOptions(
+                context,
+                &jsapi::CompileOptionsParams {
+                    force_full_parse: false,
+                    lineno: 1,
+                    file: "eval.js".into(),
+                },
+            );
+
+            let mut unrooted_return_value = jsapi::jsgc::Rooted::default();
+            let mut return_value = Rooted::new(context, &mut unrooted_return_value, jsapi::UndefinedValue());
+            let mut return_value_handle = return_value.mut_handle();
+
+            let script = "41 + 1";
+            let mut source = jsapi::MakeUtf8UnitSourceText();
+            assert!(jsapi::InitUtf8UnitSourceText(
+                context,
+                source.pin_mut(),
+                &script,
+                script.len(),
+                jsapi::SourceOwnership::Borrowed
+            ));
+
+            jsapi::Utf8SourceEvaluate(context, &owning_compile_options, source.pin_mut(), return_value_handle.into_raw());
+
+            let result = return_value.get().toInt32();
+            assert_eq!(result, 42);
+        }
+    }
+}

--- a/crates/spidermonkey-wasm/tests/eval.rs
+++ b/crates/spidermonkey-wasm/tests/eval.rs
@@ -29,7 +29,7 @@ mod eval {
                 let mut return_value = jsapi::UndefinedValue();
             );
 
-            let mut return_value_handle = return_value.mut_handle();
+            let return_value_handle = return_value.mut_handle();
 
             let script = "41 + 1";
             let mut source = jsapi::MakeUtf8UnitSourceText();


### PR DESCRIPTION
This PR implements the first iteration of the high-level stack rooting API.

It essentially introduces the following elements:

- `Rooted<T>`
- `Handle<T>`
- `MutableHandle<T>`

The Rooted implementation relies on the low-level rooted implementation to (i) register a value with its root stack (ii) remove a previously rooted value from the its root stack. 

A `Rooted<T>` will hold a reference to a low-level `RawRooted` value and to ensure that this value  will not be moved, the `Rooted<T>` implementation will pin the `RawRooted` to the stack. A `root!` helper macro is also provided to make this process safer, easier and less verbose. 