### PR TITLE
feat: Move unsafe jssffi exported functions to the js module

### DIFF
--- a/crates/spidermonkey-wasm-sys/src/lib.rs
+++ b/crates/spidermonkey-wasm-sys/src/lib.rs
@@ -149,8 +149,12 @@ pub mod jsffi {
         fn JS_Init() -> bool;
         fn JS_ShutDown();
 
+        #[rust_name = "make_default_global_class"]
         fn MakeDefaultGlobalClass() -> UniquePtr<JSClass>;
+
+        #[rust_name = "make_default_realm_options"]
         fn MakeDefaultRealmOptions() -> UniquePtr<RealmOptions>;
+
         unsafe fn MakeOwningCompileOptions(
             context: *mut JSContext,
             opts: &CompileOptionsParams,
@@ -175,9 +179,16 @@ pub mod jsffi {
         unsafe fn LeaveRealm(context: *mut JSContext, old_realm: *mut Realm);
 
         #[namespace = "JS"]
+        #[rust_name = "undefined_value"]
         fn UndefinedValue() -> Value;
+
+        #[rust_name = "to_int32"]
         fn toInt32(self: &Value) -> i32;
+
+        #[rust_name = "is_string"]
         fn isString(self: &Value) -> bool;
+
+        #[rust_name = "to_string"]
         fn toString(self: &Value) -> *mut JSString;
 
         unsafe fn MakeUtf8UnitSourceText(

--- a/crates/spidermonkey-wasm-sys/tests/integration.rs
+++ b/crates/spidermonkey-wasm-sys/tests/integration.rs
@@ -22,13 +22,13 @@ mod integration {
 
     #[test]
     fn eval() {
-        let global_class = jsffi::MakeDefaultGlobalClass();
+        let global_class = jsffi::make_default_global_class();
         let context = init_engine();
 
         unsafe {
             assert!(jsffi::InitDefaultSelfHostedCode(context));
 
-            let realm_opts = jsffi::MakeDefaultRealmOptions();
+            let realm_opts = jsffi::make_default_realm_options();
             let mut global_object = jsgc::Rooted::default();
             global_object.init(
                 context,
@@ -51,7 +51,7 @@ mod integration {
                 },
             );
 
-            let mut undefined_value = jsffi::UndefinedValue();
+            let mut undefined_value = jsffi::undefined_value();
             let rval = jsgc::MutableHandle {
                 ptr: &mut undefined_value,
                 _marker: PhantomData,
@@ -67,7 +67,7 @@ mod integration {
 
             jsffi::Utf8SourceEvaluate(context, &owning_compile_options, source.pin_mut(), rval);
 
-            let result = undefined_value.toInt32();
+            let result = undefined_value.to_int32();
             assert_eq!(result, 42);
         }
 

--- a/crates/spidermonkey-wasm/src/js.rs
+++ b/crates/spidermonkey-wasm/src/js.rs
@@ -1,0 +1,56 @@
+use anyhow::{bail, Result};
+use spidermonkey_wasm_sys::jsffi::{
+    JSClass, JSContext, JSObject, JSString, JSStringToRustString, JS_NewGlobalObject,
+    OnNewGlobalHookOption, RealmOptions, ReportException, RunJobs, ToString, Utf8IsCompilableUnit,
+};
+
+// Re-exports of safe bindings from the sys crate
+pub use spidermonkey_wasm_sys::jsffi::{
+    make_default_global_class, make_default_realm_options, undefined_value,
+};
+
+use crate::handle::{HandleObject, HandleString, HandleValue};
+
+use std::ptr;
+
+pub fn new_global_object(
+    cx: *mut JSContext,
+    class: &JSClass,
+    opts: &RealmOptions,
+) -> *mut JSObject {
+    unsafe {
+        JS_NewGlobalObject(
+            cx,
+            class,
+            ptr::null_mut(),
+            OnNewGlobalHookOption::FireOnNewGlobalHook,
+            opts,
+        )
+    }
+}
+
+pub fn run_jobs(cx: *mut JSContext) {
+    unsafe {
+        RunJobs(cx);
+    }
+}
+
+pub fn report_exception(cx: *mut JSContext) -> Result<()> {
+    if !unsafe { ReportException(cx) } {
+        bail!("Exception thrown while reporting exception");
+    }
+
+    Ok(())
+}
+
+pub fn to_string(cx: *mut JSContext, val: HandleValue) -> *mut JSString {
+    unsafe { ToString(cx, val.into_raw()) }
+}
+
+pub fn to_rust_string(cx: *mut JSContext, val: HandleString) -> String {
+    unsafe { JSStringToRustString(cx, val.into_raw()) }
+}
+
+pub fn is_compilable_unit(cx: *mut JSContext, handle: HandleObject, buffer: &str) -> bool {
+    unsafe { Utf8IsCompilableUnit(cx, handle.into_raw(), buffer) }
+}

--- a/crates/spidermonkey-wasm/src/lib.rs
+++ b/crates/spidermonkey-wasm/src/lib.rs
@@ -1,11 +1,15 @@
 pub mod compilation_options;
 pub mod handle;
+pub mod js;
 pub mod rooted;
 pub mod runtime;
 pub mod utf8_source;
 
-pub mod jsapi {
-    pub use spidermonkey_wasm_sys::jsffi::*;
-    pub use spidermonkey_wasm_sys::jsgc;
-    pub use spidermonkey_wasm_sys::jsrealm;
-}
+pub use spidermonkey_wasm_sys::jsffi::{
+    JSClass, JSContext, JSObject, OnNewGlobalHookOption, RealmOptions,
+};
+
+pub use spidermonkey_wasm_sys::jsrealm::JSAutoRealm;
+
+// Re-export low-level Rooted types for macro convenience
+pub use spidermonkey_wasm_sys::jsgc::Rooted as RawRooted;

--- a/crates/spidermonkey-wasm/src/rooted.rs
+++ b/crates/spidermonkey-wasm/src/rooted.rs
@@ -25,12 +25,12 @@ pub type RootedString<'a> = Rooted<'a, *mut JSString>;
 #[macro_export]
 macro_rules! root {
     (with($cx:expr); $(let $v:ident = $init:expr;)*) => { $(
-        let mut $v = $crate::jsapi::jsgc::Rooted::default();
+        let mut $v = $crate::RawRooted::default();
         let $v = $crate::rooted::Rooted::new($cx, &mut $v, $init);
     )*};
 
     (with($cx:expr); $(let mut $v:ident = $init:expr;)*) => { $(
-        let mut $v = $crate::jsapi::jsgc::Rooted::default();
+        let mut $v = $crate::RawRooted::default();
         let mut $v = $crate::rooted::Rooted::new($cx, &mut $v, $init);
     )*};
 }

--- a/crates/spidermonkey-wasm/tests/compile.rs
+++ b/crates/spidermonkey-wasm/tests/compile.rs
@@ -1,65 +1,58 @@
 mod compile {
     use spidermonkey_wasm::{
-        compilation_options::CompilationOptions, jsapi, root, runtime::Runtime,
-        utf8_source::Utf8Source,
+        compilation_options::CompilationOptions, js, root, runtime::Runtime,
+        utf8_source::Utf8Source, JSAutoRealm,
     };
-    use std::ptr;
 
     #[test]
     fn compile() {
         let runtime = Runtime::new().unwrap();
-        let global_class = jsapi::MakeDefaultGlobalClass();
+        let global_class = js::make_default_global_class();
         let context = runtime.cx();
 
-        unsafe {
-            let realm_opts = jsapi::MakeDefaultRealmOptions();
-            root!(with(context);
-                let global_object = jsapi::JS_NewGlobalObject(runtime.cx(), &*global_class, ptr::null_mut(), jsapi::OnNewGlobalHookOption::FireOnNewGlobalHook, &realm_opts);
-            );
+        let realm_opts = js::make_default_realm_options();
+        root!(with(context);
+         let global_object = js::new_global_object(runtime.cx(), &global_class, &realm_opts);
+        );
 
-            let global_object_handle = global_object.handle();
-            let _ar = jsapi::jsrealm::JSAutoRealm::new(context, global_object_handle.get());
+        let global_object_handle = global_object.handle();
+        let _ar = JSAutoRealm::new(context, global_object_handle.get());
 
-            root!(with(context);
-                let mut return_value = jsapi::UndefinedValue();
-            );
+        root!(with(context);
+         let mut return_value = js::undefined_value();
+        );
 
-            let return_value_handle = return_value.mut_handle();
-            let mut script = Utf8Source::new(context, "41 + 1").unwrap();
-            let compile_opts =
-                CompilationOptions::new(context, 1, false, "eval.js".into()).unwrap();
+        let return_value_handle = return_value.mut_handle();
+        let mut script = Utf8Source::new(context, "41 + 1").unwrap();
+        let compile_opts = CompilationOptions::new(context, 1, false, "eval.js".into()).unwrap();
 
-            root!(with(context);
-                let js_script = runtime.compile(&compile_opts, &mut script).unwrap();
-            );
-            runtime
-                .execute(js_script.handle(), return_value_handle)
-                .unwrap();
-            let result = return_value.get().toInt32();
-            assert_eq!(result, 42);
-        }
+        root!(with(context);
+         let js_script = runtime.compile(&compile_opts, &mut script).unwrap();
+        );
+        runtime
+            .execute(js_script.handle(), return_value_handle)
+            .unwrap();
+        let result = return_value.get().to_int32();
+        assert_eq!(result, 42);
     }
 
     #[test]
     fn compile_fail() {
         let runtime = Runtime::new().unwrap();
-        let global_class = jsapi::MakeDefaultGlobalClass();
+        let global_class = js::make_default_global_class();
         let context = runtime.cx();
 
-        unsafe {
-            let realm_opts = jsapi::MakeDefaultRealmOptions();
-            root!(with(context);
-                let global_object = jsapi::JS_NewGlobalObject(runtime.cx(), &*global_class, ptr::null_mut(), jsapi::OnNewGlobalHookOption::FireOnNewGlobalHook, &realm_opts);
-            );
+        let realm_opts = js::make_default_realm_options();
+        root!(with(context);
+            let global_object = js::new_global_object(runtime.cx(), &global_class, &realm_opts);
+        );
 
-            let global_object_handle = global_object.handle();
-            let _ar = jsapi::jsrealm::JSAutoRealm::new(context, global_object_handle.get());
+        let global_object_handle = global_object.handle();
+        let _ar = JSAutoRealm::new(context, global_object_handle.get());
 
-            let mut script = Utf8Source::new(context, "invalid syntax").unwrap();
-            let compile_opts =
-                CompilationOptions::new(context, 1, false, "eval.js".into()).unwrap();
+        let mut script = Utf8Source::new(context, "invalid syntax").unwrap();
+        let compile_opts = CompilationOptions::new(context, 1, false, "eval.js".into()).unwrap();
 
-            assert!(runtime.compile(&compile_opts, &mut script).is_err());
-        }
+        assert!(runtime.compile(&compile_opts, &mut script).is_err());
     }
 }

--- a/crates/spidermonkey-wasm/tests/eval.rs
+++ b/crates/spidermonkey-wasm/tests/eval.rs
@@ -1,39 +1,35 @@
 mod eval {
     use spidermonkey_wasm::{
-        compilation_options::CompilationOptions, jsapi, root, runtime::Runtime,
-        utf8_source::Utf8Source,
+        compilation_options::CompilationOptions, js, root, runtime::Runtime,
+        utf8_source::Utf8Source, JSAutoRealm,
     };
-    use std::ptr;
 
     #[test]
     fn eval() {
         let runtime = Runtime::new().unwrap();
-        let global_class = jsapi::MakeDefaultGlobalClass();
+        let global_class = js::make_default_global_class();
         let context = runtime.cx();
 
-        unsafe {
-            let realm_opts = jsapi::MakeDefaultRealmOptions();
-            root!(with(context);
-                let global_object = jsapi::JS_NewGlobalObject(runtime.cx(), &*global_class, ptr::null_mut(), jsapi::OnNewGlobalHookOption::FireOnNewGlobalHook, &realm_opts);
-            );
+        let realm_opts = js::make_default_realm_options();
+        root!(with(context);
+            let global_object = js::new_global_object(context, &global_class, &realm_opts);
+        );
 
-            let global_object_handle = global_object.handle();
-            let _ar = jsapi::jsrealm::JSAutoRealm::new(context, global_object_handle.get());
+        let global_object_handle = global_object.handle();
+        let _ar = JSAutoRealm::new(context, global_object_handle.get());
 
-            root!(with(context);
-                let mut return_value = jsapi::UndefinedValue();
-            );
+        root!(with(context);
+            let mut return_value = js::undefined_value();
+        );
 
-            let return_value_handle = return_value.mut_handle();
-            let mut script = Utf8Source::new(context, "41 + 1").unwrap();
-            let compile_opts =
-                CompilationOptions::new(context, 1, false, "eval.js".into()).unwrap();
+        let return_value_handle = return_value.mut_handle();
+        let mut script = Utf8Source::new(context, "41 + 1").unwrap();
+        let compile_opts = CompilationOptions::new(context, 1, false, "eval.js".into()).unwrap();
 
-            runtime
-                .eval(&compile_opts, &mut script, return_value_handle)
-                .unwrap();
-            let result = return_value.get().toInt32();
-            assert_eq!(result, 42);
-        }
+        runtime
+            .eval(&compile_opts, &mut script, return_value_handle)
+            .unwrap();
+        let result = return_value.get().to_int32();
+        assert_eq!(result, 42);
     }
 }


### PR DESCRIPTION
This commit performs a small refactoring to the structure and naming of
some functions exposed via ffi, mainly:

1. Only safe functions exposed through ffi are re-exported from the
   high-level spidermonkey-wasm crate
2. Unsafe functions are added to the js module and are exported through
   a safe variant

3. Rust names are used for safe functions that are exposed directly from the
   ffi layer