### PR TITLE
feat: Allow setting a callback to report GCs

### DIFF
--- a/crates/spidermonkey-wasm-sys/src/api.cpp
+++ b/crates/spidermonkey-wasm-sys/src/api.cpp
@@ -91,3 +91,7 @@ bool ReportException(JSContext* context) {
   return true;
 }
 
+void JS_SetGCCallbackWrapper(JSContext* context, JSGCCallback callback) {
+  JS_SetGCCallback(context, callback, nullptr);
+}
+

--- a/crates/spidermonkey-wasm-sys/src/api.h
+++ b/crates/spidermonkey-wasm-sys/src/api.h
@@ -64,3 +64,5 @@ bool Utf8IsCompilableUnit(JSContext* context, JS::HandleObject global, rust::Str
 rust::String JSStringToRustString(JSContext* context, JS::HandleString str);
 
 bool ReportException(JSContext* context);
+
+void JS_SetGCCallbackWrapper(JSContext* context, JSGCCallback callback);

--- a/crates/spidermonkey-wasm-sys/src/jsgc.rs
+++ b/crates/spidermonkey-wasm-sys/src/jsgc.rs
@@ -251,3 +251,20 @@ pub enum JSGCReason {
     NoReason = 99,
     NumReasons = 100,
 }
+
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum JSGCStatus {
+    JsgcBegin = 0,
+    JsgcEnd = 1,
+}
+
+#[repr(transparent)]
+pub struct OnJSGCCallback(
+    pub  extern "C" fn(
+        context: *mut JSContext,
+        status: JSGCStatus,
+        reason: JSGCReason,
+        data: *mut std::os::raw::c_void,
+    ),
+);

--- a/crates/spidermonkey-wasm-sys/src/lib.rs
+++ b/crates/spidermonkey-wasm-sys/src/lib.rs
@@ -45,6 +45,8 @@ impl_extern_type!(
 impl_extern_type!(jsffi::JSGCParamKey, "JSGCParamKey", cxx::kind::Trivial);
 impl_extern_type!(jsffi::GCOptions, "JS::GCOptions", cxx::kind::Trivial);
 impl_extern_type!(jsffi::GCReason, "JS::GCReason", cxx::kind::Trivial);
+impl_extern_type!(jsffi::JSGCCallback, "JSGCCallback", cxx::kind::Trivial);
+impl_extern_type!(jsffi::JSGCStatus, "JSGCStatus", cxx::kind::Trivial);
 
 #[cxx::bridge]
 pub mod jsffi {
@@ -94,6 +96,7 @@ pub mod jsffi {
         type Utf8UnitSourceText;
         type JSString;
 
+        type JSGCStatus = crate::jsgc::JSGCStatus;
         #[namespace = "JS"]
         type ContextOptions;
         #[namespace = "JS"]
@@ -155,7 +158,15 @@ pub mod jsffi {
         #[namespace = "JS"]
         unsafe fn NonIncrementalGC(context: *mut JSContext, options: GCOptions, reason: GCReason);
         type JSGCParamKey = crate::jsgc::JSGCParamKey;
+
+        type JSGCCallback = crate::jsgc::OnJSGCCallback;
+
         unsafe fn JS_SetGCParameter(context: *mut JSContext, param_key: JSGCParamKey, value: u32);
+        unsafe fn JS_MaybeGC(context: *mut JSContext);
+
+        // TODO: Support *mut c_void so that we can drop the wrapper definition and use the
+        // real function type exposed by SpiderMonkey
+        unsafe fn JS_SetGCCallbackWrapper(context: *mut JSContext, callback: JSGCCallback);
 
         unsafe fn JS_GetRuntime(context: *mut JSContext) -> *mut JSRuntime;
         unsafe fn JS_NewContext(max_bytes: u32, parent: *mut JSRuntime) -> *mut JSContext;

--- a/crates/spidermonkey-wasm/src/lib.rs
+++ b/crates/spidermonkey-wasm/src/lib.rs
@@ -12,4 +12,7 @@ pub use spidermonkey_wasm_sys::jsffi::{
 pub use spidermonkey_wasm_sys::jsrealm::JSAutoRealm;
 
 // Re-export low-level Rooted types for macro convenience
-pub use spidermonkey_wasm_sys::jsgc::Rooted as RawRooted;
+// and for GC callback definition
+pub use spidermonkey_wasm_sys::jsgc::{
+    JSGCReason, JSGCStatus, OnJSGCCallback, Rooted as RawRooted,
+};


### PR DESCRIPTION
This commit adds a simple way to report GCs. A more sophisticated
callback mechanism would be possible, but this is sufficient for
the current use case.